### PR TITLE
feat: Add SEPTA departures Android widget

### DIFF
--- a/septa-widget/.gitignore
+++ b/septa-widget/.gitignore
@@ -1,0 +1,3 @@
+/build
+/app/build
+/.gradle

--- a/septa-widget/app/build.gradle
+++ b/septa-widget/app/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.johnwesthoff.septawidget'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.johnwesthoff.septawidget"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/septa-widget/app/src/main/AndroidManifest.xml
+++ b/septa-widget/app/src/main/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar">
+
+        <receiver
+            android:name=".SeptaWidgetProvider"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info" />
+        </receiver>
+
+        <activity
+            android:name=".SeptaWidgetConfigureActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>

--- a/septa-widget/app/src/main/java/com/johnwesthoff/septawidget/SeptaWidgetConfigureActivity.java
+++ b/septa-widget/app/src/main/java/com/johnwesthoff/septawidget/SeptaWidgetConfigureActivity.java
@@ -1,0 +1,80 @@
+package com.johnwesthoff.septawidget;
+
+import android.app.Activity;
+import android.appwidget.AppWidgetManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.EditText;
+
+public class SeptaWidgetConfigureActivity extends Activity {
+
+    private static final String PREFS_NAME = "com.johnwesthoff.septawidget.SeptaWidgetProvider";
+    private static final String PREF_PREFIX_KEY = "appwidget_";
+    int mAppWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+    EditText mOriginText;
+    EditText mDestText;
+
+    public SeptaWidgetConfigureActivity() {
+        super();
+    }
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+        setResult(RESULT_CANCELED);
+        setContentView(R.layout.activity_configure);
+
+        mOriginText = findViewById(R.id.origin_edit);
+        mDestText = findViewById(R.id.dest_edit);
+        findViewById(R.id.add_button).setOnClickListener(mOnClickListener);
+
+        Intent intent = getIntent();
+        Bundle extras = intent.getExtras();
+        if (extras != null) {
+            mAppWidgetId = extras.getInt(
+                    AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
+        }
+
+        if (mAppWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish();
+            return;
+        }
+
+        mOriginText.setText(loadPref(this, mAppWidgetId, "_origin", "Suburban Station"));
+        mDestText.setText(loadPref(this, mAppWidgetId, "_dest", "30th Street Station"));
+    }
+
+    View.OnClickListener mOnClickListener = new View.OnClickListener() {
+        public void onClick(View v) {
+            final Context context = SeptaWidgetConfigureActivity.this;
+            String origin = mOriginText.getText().toString();
+            String dest = mDestText.getText().toString();
+            savePref(context, mAppWidgetId, "_origin", origin);
+            savePref(context, mAppWidgetId, "_dest", dest);
+
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+            Intent intent = new Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE, null, context, SeptaWidgetProvider.class);
+            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, new int[]{mAppWidgetId});
+            sendBroadcast(intent);
+
+            Intent resultValue = new Intent();
+            resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, mAppWidgetId);
+            setResult(RESULT_OK, resultValue);
+            finish();
+        }
+    };
+
+    static void savePref(Context context, int appWidgetId, String suffix, String text) {
+        SharedPreferences.Editor prefs = context.getSharedPreferences(PREFS_NAME, 0).edit();
+        prefs.putString(PREF_PREFIX_KEY + appWidgetId + suffix, text);
+        prefs.apply();
+    }
+
+    static String loadPref(Context context, int appWidgetId, String suffix, String defaultText) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, 0);
+        return prefs.getString(PREF_PREFIX_KEY + appWidgetId + suffix, defaultText);
+    }
+}

--- a/septa-widget/app/src/main/java/com/johnwesthoff/septawidget/SeptaWidgetProvider.java
+++ b/septa-widget/app/src/main/java/com/johnwesthoff/septawidget/SeptaWidgetProvider.java
@@ -1,0 +1,115 @@
+package com.johnwesthoff.septawidget;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.RemoteViews;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SeptaWidgetProvider extends AppWidgetProvider {
+
+    private static final String PREFS_NAME = "com.johnwesthoff.septawidget.SeptaWidgetProvider";
+    private static final String PREF_PREFIX_KEY = "appwidget_";
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        for (int appWidgetId : appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId);
+        }
+    }
+
+    private void updateAppWidget(Context context, AppWidgetManager appWidgetManager, int appWidgetId) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, 0);
+        String origin = prefs.getString(PREF_PREFIX_KEY + appWidgetId + "_origin", "Suburban Station");
+        String destination = prefs.getString(PREF_PREFIX_KEY + appWidgetId + "_dest", "30th Street Station");
+
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_layout);
+        views.setTextViewText(R.id.widget_title, origin + " to " + destination);
+        views.setTextViewText(R.id.widget_departures, "Loading...");
+
+        Intent intent = new Intent(context, SeptaWidgetProvider.class);
+        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, new int[]{appWidgetId});
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        views.setOnClickPendingIntent(R.id.widget_layout_root, pendingIntent);
+
+        appWidgetManager.updateAppWidget(appWidgetId, views);
+
+        final PendingResult pendingResult = goAsync();
+        executor.execute(() -> {
+            String departuresText = fetchDepartures(origin, destination);
+            handler.post(() -> {
+                views.setTextViewText(R.id.widget_departures, departuresText);
+                appWidgetManager.updateAppWidget(appWidgetId, views);
+                if (pendingResult != null) {
+                    pendingResult.finish();
+                }
+            });
+        });
+    }
+
+    private String fetchDepartures(String origin, String destination) {
+        try {
+            String urlString = "https://www3.septa.org/api/NextToArrive/index.php?req1=" +
+                    URLEncoder.encode(origin, "UTF-8") + "&req2=" +
+                    URLEncoder.encode(destination, "UTF-8") + "&req3=3";
+            URL url = new URL(urlString);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+
+            if (conn.getResponseCode() == 200) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                StringBuilder response = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    response.append(line);
+                }
+                reader.close();
+
+                JSONArray jsonArray = new JSONArray(response.toString());
+                StringBuilder result = new StringBuilder();
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    JSONObject obj = jsonArray.getJSONObject(i);
+                    String dep = obj.getString("orig_departure_time");
+                    String delay = obj.getString("orig_delay");
+                    String lineName = obj.getString("orig_line");
+                    result.append(dep).append(" (").append(lineName).append(")");
+                    if (!"On time".equalsIgnoreCase(delay)) {
+                         result.append(" - ").append(delay);
+                    }
+                    result.append("\n");
+                }
+                if (result.length() == 0) {
+                    return "No upcoming trains.";
+                }
+                return result.toString().trim();
+            } else {
+                return "Error: HTTP " + conn.getResponseCode();
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Error fetching data.";
+        }
+    }
+}

--- a/septa-widget/app/src/main/res/layout/activity_configure.xml
+++ b/septa-widget/app/src/main/res/layout/activity_configure.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Origin Station" />
+
+    <EditText
+        android:id="@+id/origin_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Destination Station" />
+
+    <EditText
+        android:id="@+id/dest_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text" />
+
+    <Button
+        android:id="@+id/add_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Add Widget" />
+</LinearLayout>

--- a/septa-widget/app/src/main/res/layout/widget_layout.xml
+++ b/septa-widget/app/src/main/res/layout/widget_layout.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_layout_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#DD000000"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/widget_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="SEPTA Departures"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/widget_departures"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="Loading..."
+        android:textColor="#DDDDDD"
+        android:textSize="12sp" />
+</LinearLayout>

--- a/septa-widget/app/src/main/res/values/strings.xml
+++ b/septa-widget/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SEPTA Widget</string>
+</resources>

--- a/septa-widget/app/src/main/res/xml/widget_info.xml
+++ b/septa-widget/app/src/main/res/xml/widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="200dp"
+    android:minHeight="100dp"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_layout"
+    android:configure="com.johnwesthoff.septawidget.SeptaWidgetConfigureActivity"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/septa-widget/build.gradle
+++ b/septa-widget/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.application' version '8.1.1' apply false
+}

--- a/septa-widget/gradle.properties
+++ b/septa-widget/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/septa-widget/settings.gradle
+++ b/septa-widget/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "SeptaWidget"
+include ':app'


### PR DESCRIPTION
This PR introduces an Android widget that shows the next 3 departure times between two SEPTA stations. It comes with a configuration activity where the user can enter origin and destination stations. The widget fetches data from the SEPTA NextToArrive API and displays the departure times and delays.

---
*PR created automatically by Jules for task [11842458128892168116](https://jules.google.com/task/11842458128892168116) started by @JohnathonNow*